### PR TITLE
add quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Next you need to add the plugin to the `plugins` section of your `serverless.yml
 
 ```yml
 plugins:
-  - @conqa/serverless-openapi-documentation
+  - "@conqa/serverless-openapi-documentation"
 ```
 
 You can confirm the plugin is correctly installed by running:


### PR DESCRIPTION
`@` is a restricted character in YAML spec. This is a small QoL, so that copying doesn't resolve in parse error.