### PR TITLE
Fixed the code sample for using the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Next you need to add the plugin to the `plugins` section of your `serverless.yml
 
 ```yml
 plugins:
-  - @conqa/serverless-openapi-documentation
+  - "@conqa/serverless-openapi-documentation"
 ```
 
 You can confirm the plugin is correctly installed by running:


### PR DESCRIPTION
Yaml parser doesn't like the line starting with "@" symbol, so you have to wrap it in quotation marks.