### PR TITLE
Fix attachExamples method

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -273,7 +273,7 @@ export class DefinitionGenerator {
             schema: {
               $ref: `#/components/schemas/${
                 documentationConfig.requestModels[requestModelType]
-              }`
+                }`
             }
           };
 
@@ -302,7 +302,7 @@ export class DefinitionGenerator {
   }
 
   private attachExamples(target, config) {
-    if (target.examples && Array.isArray(target.examples)) {
+    if (target.examples) {
       _.merge(config, { examples: _.cloneDeep(target.examples) });
     } else if (target.example) {
       _.merge(config, { example: _.cloneDeep(target.example) });


### PR DESCRIPTION
Per the OAS3 spec, the examples property should be an Object, not an Array