### PR TITLE
fix readme for latest serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Next you need to add the plugin to the `plugins` section of your `serverless.yml
 
 ```yml
 plugins:
-  - @conqa/serverless-openapi-documentation
+  - '@conqa/serverless-openapi-documentation'
 ```
 
 You can confirm the plugin is correctly installed by running:


### PR DESCRIPTION
serverless fails to parse the yaml because of the @ symbol. Using strings fixes this 

```
 Y A M L Exception --------------------------------------
 
  bad indentation of a sequence entry in "/Users/thomasankorn/Near-Live/NearData/services/shop-service/serverless.yml" at line 29, column 3:
      - @conqa/serverless-openapi-docume ... 
```