### PR TITLE
Add HTTP API support and normalize paths with leading slash

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -101,9 +101,12 @@ export class DefinitionGenerator {
         const httpEventConfig = httpEvent.http || httpEvent.httpApi;  // support httpApi event
 
         if (httpEventConfig.documentation) {
+          // Remove leading slash from path
+          const normalizedPath = httpEventConfig.path.replace(/^\/+/g, '');
+
           // Build OpenAPI path configuration structure for each method
           const pathConfig = {
-            [`/${httpEventConfig.path}`]: {
+            [`/${normalizedPath}`]: {
               [httpEventConfig.method.toLowerCase()]: this.getOperationFromConfig(
                 funcConfig._functionName,
                 httpEventConfig.documentation

--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -98,7 +98,7 @@ export class DefinitionGenerator {
     for (const funcConfig of config) {
       // loop through http events
       for (const httpEvent of this.getHttpEvents(funcConfig.events)) {
-        const httpEventConfig = httpEvent.http;
+        const httpEventConfig = httpEvent.http || httpEvent.httpApi;  // support httpApi event
 
         if (httpEventConfig.documentation) {
           // Build OpenAPI path configuration structure for each method
@@ -377,6 +377,6 @@ export class DefinitionGenerator {
   }
 
   private getHttpEvents(funcConfig) {
-    return funcConfig.filter(event => (event.http ? true : false));
+    return funcConfig.filter(event => ((event.http || event.httpApi) ? true : false));
   }
 }


### PR DESCRIPTION
Changes

- Simple implementation of handling http api events
- Parse paths properly when paths are starting with slashes like '/foo/bar' instead of 'foo/bar'