### PR TITLE
Do not rely on `serverless.variables`

### DIFF
--- a/src/ServerlessOpenApiDocumentation.ts
+++ b/src/ServerlessOpenApiDocumentation.ts
@@ -26,12 +26,8 @@ interface Service {
   custom: CustomVars;
 }
 
-interface Variables {
-  service: Service;
-}
-
 interface FullServerless extends Serverless {
-  variables: Variables;
+  service: Service;
   processedInput: ProcessedInput;
 }
 
@@ -53,7 +49,7 @@ export class ServerlessOpenApiDocumentation {
     // pull the serverless instance into our class vars
     this.serverless = serverless;
     // Serverless service custom variables
-    this.customVars = this.serverless.variables.service.custom;
+    this.customVars = this.serverless.service.custom;
 
     // Declare the commands this plugin exposes for the Serverless CLI
     this.commands = {


### PR DESCRIPTION
 `serverless.variables` is an interface for old variables resolver which will be removed in context of v3 release of the Framework.

In this plugin it's purely used to access `service` configuration, which is also accessible directly at `serverless` instance.